### PR TITLE
Add structured scene flows for chapters 1-10

### DIFF
--- a/data/scenes/ch10_finale.json
+++ b/data/scenes/ch10_finale.json
@@ -1,0 +1,72 @@
+[
+  {
+    "id": "ch10.setup",
+    "participants": ["Alex", "Mira", "Orion"],
+    "messages": [
+      { "sys": "status", "textId": "ch10.setup_status", "sfx": { "on": "checkpoint", "vol": 0.95 }, "anim": { "name": "fadeIn", "durationMs": 340 } },
+      { "from": "Mira", "textId": "ch10.mira_setup", "sfx": { "on": "message_in" } },
+      { "from": "Alex", "choices": [ { "id": "balance", "labelId": "ui.next", "goto": "ch10.balance", "sfx": { "on": "choice_show" } } ] }
+    ]
+  },
+  {
+    "id": "ch10.balance",
+    "participants": ["Alex", "Orion"],
+    "messages": [
+      { "sys": "typing", "who": "Orion", "ms": 1100, "sfx": { "on": "typing_start" } },
+      { "from": "Orion", "textId": "ch10.orion_balance", "sfx": { "on": "message_in" } },
+      { "from": "Alex", "choices": [ { "id": "evaluate", "labelId": "ui.next", "goto": "ch10.evaluate", "sfx": { "on": "choice_show" }, "haptics": "medium" } ] }
+    ]
+  },
+  {
+    "id": "ch10.evaluate",
+    "participants": ["Alex", "System"],
+    "messages": [
+      { "sys": "typing", "who": "System", "ms": 800, "sfx": { "on": "typing_start" } },
+      { "from": "System", "textId": "ch10.system_summary", "sfx": { "on": "message_in" } },
+      {
+        "from": "Alex",
+        "choices": [
+          { "id": "good", "labelId": "ch10.choice.good", "goto": "ch10.ending.good", "requires": { "trust.Mira": { ">=": 6 }, "trust.Orion": { ">=": 4 }, "flags.pressRelease": true, "flags.lockerOpened": true }, "sfx": { "on": "choice_confirm" } },
+          { "id": "secret", "labelId": "ch10.choice.secret", "goto": "ch10.ending.secret", "requires": { "trust.Mira": { ">=": 5 }, "flags.hasKey": true, "flags.pressRelease": false }, "sfx": { "on": "choice_confirm" } },
+          { "id": "bittersweet", "labelId": "ch10.choice.bittersweet", "goto": "ch10.ending.bittersweet", "requires": { "trust.Mira": { ">=": 3 } }, "sfx": { "on": "choice_confirm" } },
+          { "id": "bad", "labelId": "ch10.choice.bad", "goto": "ch10.ending.bad", "sfx": { "on": "choice_confirm" } }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "ch10.ending.good",
+    "participants": ["Alex", "Mira", "Orion"],
+    "messages": [
+      { "from": "Mira", "textId": "ch10.good_mira", "sfx": { "on": "message_in", "vol": 0.95 }, "anim": { "name": "fadeIn", "durationMs": 320 } },
+      { "from": "Orion", "textId": "ch10.good_orion", "sfx": { "on": "message_in" } },
+      { "sys": "status", "textId": "ch10.good_outro", "sfx": { "on": "checkpoint" }, "haptics": "soft" }
+    ]
+  },
+  {
+    "id": "ch10.ending.bittersweet",
+    "participants": ["Alex", "Mira", "Orion"],
+    "messages": [
+      { "from": "Mira", "textId": "ch10.bittersweet_mira", "sfx": { "on": "message_in" } },
+      { "from": "Orion", "textId": "ch10.bittersweet_orion", "sfx": { "on": "message_in", "vol": 0.8 } },
+      { "sys": "status", "textId": "ch10.bittersweet_outro", "sfx": { "on": "message_in" } }
+    ]
+  },
+  {
+    "id": "ch10.ending.bad",
+    "participants": ["Alex", "Mira", "Orion"],
+    "messages": [
+      { "from": "Orion", "textId": "ch10.bad_orion", "sfx": { "on": "message_in", "vol": 0.7 }, "anim": { "name": "shake", "durationMs": 240 } },
+      { "from": "Mira", "textId": "ch10.bad_mira", "sfx": { "on": "message_in" } },
+      { "sys": "status", "textId": "ch10.bad_outro", "sfx": { "on": "error" }, "haptics": "heavy" }
+    ]
+  },
+  {
+    "id": "ch10.ending.secret",
+    "participants": ["Alex", "Mira"],
+    "messages": [
+      { "from": "Mira", "textId": "ch10.secret_mira", "sfx": { "on": "message_in", "vol": 0.95 }, "anim": { "name": "fadeIn", "durationMs": 340 } },
+      { "sys": "status", "textId": "ch10.secret_outro", "sfx": { "on": "checkpoint" }, "haptics": "medium" }
+    ]
+  }
+]

--- a/data/scenes/ch1_intro.json
+++ b/data/scenes/ch1_intro.json
@@ -3,41 +3,57 @@
     "id": "ch1.splash",
     "participants": ["System"],
     "messages": [
-      { "sys": "status", "textId": "ui.title", "anim": { "name": "fadeIn", "durationMs": 500 }, "sfx": { "on": "checkpoint", "vol": 0.8 } },
+      {
+        "sys": "status",
+        "textId": "ui.title",
+        "anim": { "name": "fadeIn", "durationMs": 500 },
+        "sfx": { "on": "checkpoint", "vol": 0.8 }
+      },
       {
         "from": "System",
         "choices": [
-          { "id": "lang_uk", "labelId": "ui.lang.uk", "goto": "ch1.langSet.uk", "sfx": { "on": "choice_show" } },
-          { "id": "lang_ru", "labelId": "ui.lang.ru", "goto": "ch1.langSet.ru", "sfx": { "on": "choice_show" } }
+          {
+            "id": "lang_uk",
+            "labelId": "ui.lang.uk",
+            "goto": "ch1.tutorial",
+            "effects": { "flags.lang": "uk" },
+            "sfx": { "on": "choice_show" },
+            "haptics": "light"
+          },
+          {
+            "id": "lang_ru",
+            "labelId": "ui.lang.ru",
+            "goto": "ch1.tutorial",
+            "effects": { "flags.lang": "ru" },
+            "sfx": { "on": "choice_show" },
+            "haptics": "light"
+          }
         ]
       }
-    ]
-  },
-  {
-    "id": "ch1.langSet.uk",
-    "participants": ["System"],
-    "messages": [
-      { "effects": { "flags.lang": "uk" } },
-      { "sys": "status", "textId": "ui.lang.set.uk", "anim": { "name": "pulse", "durationMs": 300 }, "sfx": { "on": "checkpoint" } },
-      { "from": "System", "choices": [ { "id": "start", "labelId": "ui.start", "goto": "ch1.tutorial" } ] }
-    ]
-  },
-  {
-    "id": "ch1.langSet.ru",
-    "participants": ["System"],
-    "messages": [
-      { "effects": { "flags.lang": "ru" } },
-      { "sys": "status", "textId": "ui.lang.set.ru", "anim": { "name": "pulse", "durationMs": 300 }, "sfx": { "on": "checkpoint" } },
-      { "from": "System", "choices": [ { "id": "start", "labelId": "ui.start", "goto": "ch1.tutorial" } ] }
     ]
   },
   {
     "id": "ch1.tutorial",
     "participants": ["System"],
     "messages": [
-      { "from": "System", "textId": "ui.tutorial.choices", "anim": { "name": "fadeIn", "durationMs": 280 }, "sfx": { "on": "message_in" } },
-      { "from": "System", "textId": "ui.tutorial.typing", "anim": { "name": "fadeIn", "durationMs": 280 }, "sfx": { "on": "message_in" } },
-      { "from": "System", "choices": [ { "id": "go", "labelId": "ui.continue", "goto": "ch1.firstPing" } ] }
+      {
+        "from": "System",
+        "textId": "ui.tutorial.choices",
+        "anim": { "name": "fadeIn", "durationMs": 280 },
+        "sfx": { "on": "message_in" }
+      },
+      {
+        "from": "System",
+        "textId": "ui.tutorial.typing",
+        "anim": { "name": "fadeIn", "durationMs": 280 },
+        "sfx": { "on": "message_in" }
+      },
+      {
+        "from": "System",
+        "choices": [
+          { "id": "start", "labelId": "ui.continue", "goto": "ch1.firstPing", "sfx": { "on": "choice_show" } }
+        ]
+      }
     ]
   },
   {
@@ -50,87 +66,31 @@
       {
         "from": "Alex",
         "choices": [
-          { "id": "askWho", "labelId": "ch1.choice.askWho", "goto": "ch1.deletedMechanic", "sfx": { "on": "choice_show" } },
-          { "id": "call", "labelId": "ch1.choice.call", "goto": "ch1.call", "effects": { "trust.Sam": 5 }, "sfx": { "on": "choice_show" } }
+          { "id": "askWho", "labelId": "ch1.choice.askWho", "goto": "ch1.deletedHint", "effects": { "trust.Sam": 1 }, "sfx": { "on": "choice_show" } },
+          { "id": "reassure", "labelId": "ch1.choice.reassure", "goto": "ch1.bridge", "effects": { "trust.Sam": 3 }, "sfx": { "on": "choice_show" } }
         ]
       }
     ]
   },
   {
-    "id": "ch1.call",
+    "id": "ch1.deletedHint",
     "participants": ["Alex", "Sam"],
     "messages": [
-      { "sys": "typing", "who": "Sam", "ms": 1400, "sfx": { "on": "typing_start" } },
-      { "from": "Sam", "textId": "ch1.call_1", "sfx": { "on": "message_in" }, "anim": { "name": "fadeIn", "durationMs": 260 } },
-      { "sys": "deleted", "ref": "m001", "sfx": { "on": "deleted", "vol": 0.9 }, "anim": { "name": "deleteFlash", "durationMs": 320 }, "effects": { "flags.seenDeleted": true } },
-      { "from": "Sam", "media": { "kind": "image", "src": "partial.jpg", "captionId": "ch1.partial_caption" }, "sfx": { "on": "message_in" } },
-      {
-        "from": "Alex",
-        "choices": [
-          { "id": "press", "labelId": "ch1.choice.details", "goto": "ch1.detailsA" },
-          { "id": "when", "labelId": "ch1.choice.when", "goto": "ch1.detailsB", "effects": { "time.clock": "+5" } }
-        ]
-      }
-    ]
-  },
-  {
-    "id": "ch1.deletedMechanic",
-    "participants": ["Alex", "Sam"],
-    "messages": [
-      { "sys": "timer", "timerMs": 30000, "sfx": { "on": "timer_start" }, "onExpire": { "goto": "ch1.late", "effects": { "trust.Sam": -2 } } },
+      { "sys": "timer", "timerMs": 30000, "sfx": { "on": "timer_start" }, "onExpire": { "goto": "ch1.bridge", "effects": { "trust.Sam": -2 } } },
       { "sys": "typing", "who": "Sam", "ms": 900, "sfx": { "on": "typing_start" } },
-      { "from": "Sam", "textId": "ch1.deleted_hint", "sfx": { "on": "message_in" }, "anim": { "name": "fadeIn", "durationMs": 200 } },
-      { "sys": "deleted", "ref": "m001", "sfx": { "on": "deleted" }, "anim": { "name": "deleteFlash", "durationMs": 320 }, "effects": { "flags.seenDeleted": true } },
-      { "from": "Sam", "textId": "ch1.mira_name", "sfx": { "on": "message_in" } },
-      {
-        "from": "Alex",
-        "choices": [
-          { "id": "askMira", "labelId": "ch1.choice.askMira", "goto": "ch1.contact", "effects": { "trust.Sam": 2 } },
-          { "id": "pressDetails", "labelId": "ch1.choice.more", "goto": "ch1.detailsA", "effects": { "trust.Sam": -1 } }
-        ]
-      }
+      { "sys": "deleted", "ref": "m001", "sfx": { "on": "deleted", "vol": 0.9 }, "anim": { "name": "deleteFlash", "durationMs": 320 }, "effects": { "flags.seenDeleted": true } },
+      { "from": "Sam", "textId": "ch1.deleted_hint", "sfx": { "on": "message_in" } },
+      { "from": "Alex", "choices": [ { "id": "continue", "labelId": "ui.next", "goto": "ch1.bridge", "sfx": { "on": "choice_show" } } ] }
     ]
   },
   {
-    "id": "ch1.late",
-    "participants": ["Alex", "Sam"],
+    "id": "ch1.bridge",
+    "participants": ["Alex", "Sam", "System"],
     "messages": [
-      { "from": "Sam", "textId": "ch1.late_1", "sfx": { "on": "message_in" }, "effects": { "trust.Sam": -3 } },
-      { "from": "Sam", "textId": "ch1.mira_name_short", "sfx": { "on": "message_in" } },
-      { "sys": "addContact", "who": "Mira", "sfx": { "on": "checkpoint" }, "haptics": "medium" },
-      { "from": "Alex", "choices": [ { "id": "goMira", "labelId": "ch1.choice.toMira", "goto": "ch1.miraIntro" } ] }
-    ]
-  },
-  {
-    "id": "ch1.contact",
-    "participants": ["Alex", "Sam", "Mira"],
-    "messages": [
+      { "from": "Sam", "textId": "ch1.bridge_intro", "sfx": { "on": "message_in" }, "anim": { "name": "fadeIn", "durationMs": 240 } },
       { "sys": "addContact", "who": "Mira", "sfx": { "on": "checkpoint", "vol": 0.9 }, "haptics": "medium" },
-      { "from": "Sam", "textId": "ch1.intro_mira", "sfx": { "on": "message_in" } },
-      { "from": "Mira", "textId": "ch1.mira_skeptic", "sfx": { "on": "message_in" } },
-      {
-        "from": "Alex",
-        "choices": [
-          { "id": "soft", "labelId": "ch1.choice.soft", "goto": "ch1.miraIntro", "effects": { "trust.Mira": 3 } },
-          { "id": "hard", "labelId": "ch1.choice.hard", "goto": "ch1.miraIntro", "effects": { "trust.Mira": -4 } }
-        ]
-      }
-    ]
-  },
-  {
-    "id": "ch1.detailsA",
-    "participants": ["Alex", "Sam"],
-    "messages": [
-      { "from": "Sam", "textId": "ch1.details_a", "sfx": { "on": "message_in" } },
-      { "from": "Alex", "choices": [ { "id": "toMira", "labelId": "ch1.choice.toMira", "goto": "ch1.miraIntro" } ] }
-    ]
-  },
-  {
-    "id": "ch1.detailsB",
-    "participants": ["Alex", "Sam"],
-    "messages": [
-      { "from": "Sam", "textId": "ch1.details_b", "sfx": { "on": "message_in" } },
-      { "from": "Alex", "choices": [ { "id": "toMira", "labelId": "ch1.choice.toMira", "goto": "ch1.miraIntro" } ] }
+      { "from": "System", "textId": "ch1.bridge_notify", "sfx": { "on": "message_in" } },
+      { "from": "Alex", "choices": [ { "id": "pingMira", "labelId": "ch1.choice.toMira", "goto": "ch1.miraIntro", "sfx": { "on": "choice_show" } } ] }
     ]
   },
   {
@@ -143,8 +103,8 @@
       {
         "from": "Alex",
         "choices": [
-          { "id": "ok", "labelId": "ui.next", "goto": "ch2.entry", "effects": { "time.clock": "+10" } },
-          { "id": "push", "labelId": "ch1.choice.push", "goto": "ch2.altEntry", "effects": { "trust.Mira": -1 } }
+          { "id": "steady", "labelId": "ui.next", "goto": "ch2.entry", "effects": { "time.clock": "+10", "trust.Mira": 1 }, "sfx": { "on": "choice_show" } },
+          { "id": "push", "labelId": "ch1.choice.push", "goto": "ch2.altEntry", "effects": { "trust.Mira": -2 }, "sfx": { "on": "choice_show" } }
         ]
       }
     ]

--- a/data/scenes/ch2_deadline.json
+++ b/data/scenes/ch2_deadline.json
@@ -3,29 +3,14 @@
     "id": "ch2.entry",
     "participants": ["Alex", "Orion", "System"],
     "messages": [
-      {
-        "sys": "status",
-        "textId": "ch2.orion_status",
-        "sfx": { "on": "message_in", "vol": 0.8 },
-        "anim": { "name": "fadeIn", "durationMs": 280 }
-      },
+      { "sys": "status", "textId": "ch2.orion_status", "sfx": { "on": "message_in", "vol": 0.8 }, "anim": { "name": "fadeIn", "durationMs": 280 } },
+      { "sys": "typing", "who": "Orion", "ms": 900, "sfx": { "on": "typing_start" } },
+      { "from": "Orion", "textId": "ch2.orion_probe", "sfx": { "on": "message_in" }, "anim": { "name": "fadeIn", "durationMs": 240 } },
       {
         "from": "Alex",
         "choices": [
-          {
-            "id": "wait",
-            "labelId": "ch2.choice.wait",
-            "goto": "ch2.waitHold",
-            "effects": { "time.clock": "+5" },
-            "sfx": { "on": "choice_show" }
-          },
-          {
-            "id": "press",
-            "labelId": "ch2.choice.press",
-            "goto": "ch2.pressPing",
-            "effects": { "trust.Orion": -2 },
-            "sfx": { "on": "choice_show" }
-          }
+          { "id": "wait", "labelId": "ch2.choice.wait", "goto": "ch2.waitHold", "effects": { "time.clock": "+5" }, "sfx": { "on": "choice_show" } },
+          { "id": "press", "labelId": "ch2.choice.press", "goto": "ch2.pressPing", "effects": { "trust.Orion": -2 }, "sfx": { "on": "choice_show" } }
         ]
       }
     ]
@@ -34,57 +19,20 @@
     "id": "ch2.waitHold",
     "participants": ["Alex", "Orion"],
     "messages": [
-      {
-        "sys": "timer",
-        "timerMs": 20000,
-        "sfx": { "on": "timer_start", "vol": 0.7 },
-        "onExpire": {
-          "goto": "ch2.waitReply",
-          "effects": { "time.clock": "+5" }
-        }
-      },
-      {
-        "sys": "typing",
-        "who": "Orion",
-        "ms": 1200,
-        "sfx": { "on": "typing_start", "vol": 0.6 }
-      }
+      { "sys": "timer", "timerMs": 20000, "sfx": { "on": "timer_start", "vol": 0.7 }, "onExpire": { "goto": "ch2.waitReply", "effects": { "time.clock": "+5" } } },
+      { "sys": "typing", "who": "Orion", "ms": 1200, "sfx": { "on": "typing_start", "vol": 0.6 } }
     ]
   },
   {
     "id": "ch2.waitReply",
     "participants": ["Alex", "Orion"],
     "messages": [
-      {
-        "sys": "typing",
-        "who": "Orion",
-        "ms": 900,
-        "sfx": { "on": "typing_start" }
-      },
-      {
-        "from": "Orion",
-        "textId": "ch2.orion_reply_honest",
-        "effects": { "trust.Orion": 3 },
-        "sfx": { "on": "message_in" },
-        "anim": { "name": "fadeIn", "durationMs": 260 }
-      },
+      { "from": "Orion", "textId": "ch2.orion_reply_honest", "effects": { "trust.Orion": 3 }, "sfx": { "on": "message_in" }, "anim": { "name": "fadeIn", "durationMs": 260 } },
       {
         "from": "Alex",
         "choices": [
-          {
-            "id": "accept",
-            "labelId": "ch2.choice.wait",
-            "goto": "ch2.bridge",
-            "effects": { "trust.Orion": 2 },
-            "sfx": { "on": "choice_show" }
-          },
-          {
-            "id": "push",
-            "labelId": "ch2.choice.press",
-            "goto": "ch2.pressSilence",
-            "effects": { "trust.Orion": -1 },
-            "sfx": { "on": "choice_show" }
-          }
+          { "id": "accept", "labelId": "ui.next", "goto": "ch2.trustBridge", "effects": { "trust.Orion": 2 }, "sfx": { "on": "choice_show" } },
+          { "id": "push", "labelId": "ch2.choice.press", "goto": "ch2.pressPing", "effects": { "trust.Orion": -1 }, "sfx": { "on": "choice_show" } }
         ]
       }
     ]
@@ -93,36 +41,13 @@
     "id": "ch2.pressPing",
     "participants": ["Alex", "Orion"],
     "messages": [
-      {
-        "sys": "typing",
-        "who": "Orion",
-        "ms": 700,
-        "sfx": { "on": "typing_start" }
-      },
-      {
-        "from": "Orion",
-        "textId": "ch2.orion_reply_deflect",
-        "effects": { "trust.Orion": -2 },
-        "sfx": { "on": "message_in" },
-        "anim": { "name": "fadeIn", "durationMs": 220 }
-      },
+      { "sys": "typing", "who": "Orion", "ms": 700, "sfx": { "on": "typing_start" } },
+      { "from": "Orion", "textId": "ch2.orion_reply_deflect", "effects": { "trust.Orion": -2 }, "sfx": { "on": "message_in" }, "anim": { "name": "fadeIn", "durationMs": 220 } },
       {
         "from": "Alex",
         "choices": [
-          {
-            "id": "pressAgain",
-            "labelId": "ch2.choice.press",
-            "goto": "ch2.pressSilence",
-            "effects": { "trust.Orion": -2 },
-            "sfx": { "on": "choice_show" }
-          },
-          {
-            "id": "backOff",
-            "labelId": "ch2.choice.wait",
-            "goto": "ch2.waitHold",
-            "effects": { "time.clock": "+3" },
-            "sfx": { "on": "choice_show" }
-          }
+          { "id": "pressAgain", "labelId": "ch2.choice.press", "goto": "ch2.pressSilence", "effects": { "trust.Orion": -2 }, "sfx": { "on": "choice_show" } },
+          { "id": "backOff", "labelId": "ch2.choice.wait", "goto": "ch2.waitHold", "effects": { "time.clock": "+3" }, "sfx": { "on": "choice_show" } }
         ]
       }
     ]
@@ -131,48 +56,36 @@
     "id": "ch2.pressSilence",
     "participants": ["Alex", "Orion"],
     "messages": [
+      { "sys": "status", "textId": "ch2.orion_status", "sfx": { "on": "message_in", "vol": 0.6 }, "anim": { "name": "fadeIn", "durationMs": 200 } },
+      { "sys": "timer", "timerMs": 15000, "sfx": { "on": "timer_start" }, "onExpire": { "goto": "ch2.trustBridge", "effects": { "trust.Orion": -1, "time.clock": "+4" } } }
+    ]
+  },
+  {
+    "id": "ch2.trustBridge",
+    "participants": ["Alex", "Orion", "System"],
+    "messages": [
+      { "sys": "typing", "who": "Orion", "ms": 1100, "sfx": { "on": "typing_start" } },
+      { "from": "Orion", "textId": "ch2.orion_bridge", "sfx": { "on": "message_in" }, "anim": { "name": "fadeIn", "durationMs": 260 } },
+      { "from": "System", "textId": "ch2.hub_prompt", "sfx": { "on": "message_in", "vol": 0.85 } },
       {
-        "sys": "status",
-        "textId": "ch2.orion_status",
-        "sfx": { "on": "message_in", "vol": 0.6 },
-        "anim": { "name": "fadeIn", "durationMs": 200 }
-      },
-      {
-        "sys": "timer",
-        "timerMs": 15000,
-        "sfx": { "on": "timer_start" },
-        "onExpire": {
-          "goto": "ch2.bridge",
-          "effects": { "trust.Orion": -1, "time.clock": "+4" }
-        }
+        "from": "Alex",
+        "choices": [
+          { "id": "toHub", "labelId": "ui.next", "goto": "ch3.hub", "effects": { "trust.Orion": 1 }, "sfx": { "on": "choice_show" } }
+        ]
       }
     ]
   },
   {
-    "id": "ch2.bridge",
-    "participants": ["Alex", "System", "Mira"],
+    "id": "ch2.altEntry",
+    "participants": ["Alex", "Orion"],
     "messages": [
-      {
-        "sys": "addContact",
-        "who": "Mira",
-        "sfx": { "on": "checkpoint", "vol": 0.9 },
-        "haptics": "medium"
-      },
-      {
-        "from": "System",
-        "textId": "ch2.mira_ping",
-        "sfx": { "on": "message_in" },
-        "anim": { "name": "fadeIn", "durationMs": 240 }
-      },
+      { "sys": "typing", "who": "Orion", "ms": 1000, "sfx": { "on": "typing_start", "vol": 0.7 } },
+      { "from": "Orion", "textId": "ch2.orion_alt_entry", "effects": { "trust.Orion": -1 }, "sfx": { "on": "message_in" }, "anim": { "name": "fadeIn", "durationMs": 260 } },
       {
         "from": "Alex",
         "choices": [
-          {
-            "id": "toMira",
-            "labelId": "ui.next",
-            "goto": "ch3.entry",
-            "sfx": { "on": "choice_show" }
-          }
+          { "id": "steady", "labelId": "ch2.choice.wait", "goto": "ch2.waitHold", "sfx": { "on": "choice_show" } },
+          { "id": "demand", "labelId": "ch2.choice.press", "goto": "ch2.pressPing", "effects": { "trust.Orion": -2 }, "sfx": { "on": "choice_show" } }
         ]
       }
     ]

--- a/data/scenes/ch3_strategy.json
+++ b/data/scenes/ch3_strategy.json
@@ -1,0 +1,76 @@
+[
+  {
+    "id": "ch3.hub",
+    "participants": ["Alex", "Mira", "Orion"],
+    "messages": [
+      { "sys": "status", "textId": "ch3.hub_status", "sfx": { "on": "checkpoint", "vol": 0.85 }, "anim": { "name": "fadeIn", "durationMs": 320 } },
+      { "from": "Mira", "textId": "ch3.mira_brief", "sfx": { "on": "message_in" } },
+      { "from": "Orion", "textId": "ch3.orion_sync", "sfx": { "on": "message_in" }, "anim": { "name": "fadeIn", "durationMs": 240 } },
+      {
+        "from": "Alex",
+        "choices": [
+          { "id": "hearMira", "labelId": "ch3.choice.mira", "goto": "ch3.miraBrief", "sfx": { "on": "choice_show" } },
+          { "id": "hearOrion", "labelId": "ch3.choice.orion", "goto": "ch3.orionPlan", "sfx": { "on": "choice_show" } }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "ch3.miraBrief",
+    "participants": ["Alex", "Mira"],
+    "messages": [
+      { "sys": "typing", "who": "Mira", "ms": 1200, "sfx": { "on": "typing_start" } },
+      { "from": "Mira", "textId": "ch3.mira_trust_low", "effects": { "trust.Mira": 1 }, "sfx": { "on": "message_in" }, "anim": { "name": "fadeIn", "durationMs": 220 } },
+      { "from": "Alex", "choices": [ { "id": "loopBack", "labelId": "ui.next", "goto": "ch3.orionPlan", "sfx": { "on": "choice_show" } } ] }
+    ]
+  },
+  {
+    "id": "ch3.orionPlan",
+    "participants": ["Alex", "Orion"],
+    "messages": [
+      { "sys": "typing", "who": "Orion", "ms": 900, "sfx": { "on": "typing_start" } },
+      { "from": "Orion", "textId": "ch3.orion_plan", "effects": { "trust.Orion": 1 }, "sfx": { "on": "message_in" } },
+      { "from": "Alex", "choices": [ { "id": "empathy", "labelId": "ch3.choice.empathy", "goto": "ch3.empathy", "sfx": { "on": "choice_show" } } ] }
+    ]
+  },
+  {
+    "id": "ch3.empathy",
+    "participants": ["Alex", "Mira"],
+    "messages": [
+      { "sys": "typing", "who": "Mira", "ms": 1400, "sfx": { "on": "typing_start", "vol": 0.7 } },
+      { "from": "Mira", "textId": "ch3.mira_empathy_prompt", "sfx": { "on": "message_in" } },
+      {
+        "from": "Alex",
+        "choices": [
+          { "id": "comfort", "labelId": "ch3.choice.comfort", "goto": "ch3.keyDecision", "effects": { "trust.Mira": 2 }, "sfx": { "on": "choice_show" }, "haptics": "soft" },
+          { "id": "focusMission", "labelId": "ch3.choice.focus", "goto": "ch3.keyDecision", "effects": { "trust.Mira": -2 }, "sfx": { "on": "choice_show" } }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "ch3.keyDecision",
+    "participants": ["Alex", "Mira", "Orion"],
+    "messages": [
+      { "from": "Orion", "textId": "ch3.orion_key_check", "sfx": { "on": "message_in" }, "anim": { "name": "pulse", "durationMs": 200 } },
+      { "from": "Mira", "textId": "ch3.mira_key_warning", "effects": { "flags.hasKey": false }, "sfx": { "on": "message_in" } },
+      {
+        "from": "Alex",
+        "choices": [
+          { "id": "pressNow", "labelId": "ch3.choice.press", "goto": "ch3.press", "effects": { "trust.Mira": -1 }, "sfx": { "on": "choice_show" } },
+          { "id": "prepMore", "labelId": "ch3.choice.prepare", "goto": "ch3.miraBrief", "effects": { "time.clock": "+4" }, "sfx": { "on": "choice_show" } }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "ch3.press",
+    "participants": ["Alex", "Mira", "Orion"],
+    "messages": [
+      { "sys": "typing", "who": "Orion", "ms": 800, "sfx": { "on": "typing_start" } },
+      { "from": "Orion", "textId": "ch3.orion_press_ready", "sfx": { "on": "message_in", "vol": 0.9 } },
+      { "from": "Mira", "textId": "ch3.mira_press_pledge", "effects": { "trust.Mira": 1 }, "sfx": { "on": "message_in" }, "anim": { "name": "fadeIn", "durationMs": 220 } },
+      { "from": "Alex", "choices": [ { "id": "toEntry", "labelId": "ui.next", "goto": "ch4.entry", "sfx": { "on": "choice_show" } } ] }
+    ]
+  }
+]

--- a/data/scenes/ch4_mission.json
+++ b/data/scenes/ch4_mission.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ch4.entry",
+    "participants": ["Alex", "Mira"],
+    "messages": [
+      { "sys": "status", "textId": "ch4.entry_status", "sfx": { "on": "checkpoint" }, "anim": { "name": "fadeIn", "durationMs": 320 } },
+      { "from": "Mira", "textId": "ch4.mira_brief", "sfx": { "on": "message_in" } },
+      { "from": "Alex", "choices": [ { "id": "prep", "labelId": "ui.next", "goto": "ch4.sync", "sfx": { "on": "choice_show" } } ] }
+    ]
+  },
+  {
+    "id": "ch4.sync",
+    "participants": ["Alex", "Orion"],
+    "messages": [
+      { "sys": "typing", "who": "Orion", "ms": 1000, "sfx": { "on": "typing_start", "vol": 0.75 } },
+      { "from": "Orion", "textId": "ch4.orion_sync", "sfx": { "on": "message_in" }, "anim": { "name": "fadeIn", "durationMs": 240 } },
+      { "from": "Alex", "choices": [ { "id": "calibrate", "labelId": "ch4.choice.calibrate", "goto": "ch4.calibrate", "sfx": { "on": "choice_show" } } ] }
+    ]
+  },
+  {
+    "id": "ch4.calibrate",
+    "participants": ["Alex", "System"],
+    "messages": [
+      { "sys": "typing", "who": "System", "ms": 600, "sfx": { "on": "typing_start" } },
+      { "from": "System", "textId": "ch4.system_hint", "sfx": { "on": "message_in" } },
+      { "from": "Alex", "choices": [ { "id": "start", "labelId": "ui.start", "goto": "ch4.challenge", "sfx": { "on": "choice_show" }, "haptics": "medium" } ] }
+    ]
+  },
+  {
+    "id": "ch4.challenge",
+    "participants": ["Alex", "System"],
+    "messages": [
+      {
+        "miniGame": {
+          "kind": "timestamps",
+          "id": "mg4.timestamps",
+          "params": { "maxTries": 3, "timeLimitMs": 90000 },
+          "onSuccess": { "goto": "ch4.success", "effects": { "trust.Mira": 2, "flags.hasKey": true }, "sfx": { "on": "checkpoint" }, "haptics": "medium" },
+          "onFail": { "goto": "ch4.fail", "effects": { "trust.Mira": -3 }, "sfx": { "on": "error" }, "haptics": "heavy" }
+        }
+      }
+    ]
+  },
+  {
+    "id": "ch4.success",
+    "participants": ["Alex", "Mira", "Orion"],
+    "messages": [
+      { "from": "Mira", "textId": "ch4.mira_success", "sfx": { "on": "message_in", "vol": 0.9 }, "anim": { "name": "fadeIn", "durationMs": 240 } },
+      { "from": "Orion", "textId": "ch4.orion_success", "effects": { "trust.Orion": 2 }, "sfx": { "on": "message_in" } },
+      { "from": "Alex", "choices": [ { "id": "advance", "labelId": "ui.next", "goto": "ch5.media", "sfx": { "on": "choice_show" } } ] }
+    ]
+  },
+  {
+    "id": "ch4.fail",
+    "participants": ["Alex", "Mira", "Orion"],
+    "messages": [
+      { "from": "Mira", "textId": "ch4.mira_fail", "effects": { "trust.Mira": -1 }, "sfx": { "on": "message_in", "vol": 0.8 } },
+      { "from": "Orion", "textId": "ch4.orion_fail", "effects": { "trust.Orion": -2 }, "sfx": { "on": "message_in" }, "anim": { "name": "shake", "durationMs": 220 } },
+      { "from": "Alex", "choices": [ { "id": "advance", "labelId": "ui.next", "goto": "ch5.media", "sfx": { "on": "choice_show" } } ] }
+    ]
+  }
+]

--- a/data/scenes/ch5_media.json
+++ b/data/scenes/ch5_media.json
@@ -1,0 +1,68 @@
+[
+  {
+    "id": "ch5.media",
+    "participants": ["Alex", "Mira", "Orion"],
+    "messages": [
+      { "sys": "status", "textId": "ch5.media_status", "sfx": { "on": "checkpoint" }, "anim": { "name": "fadeIn", "durationMs": 320 } },
+      { "from": "Orion", "textId": "ch5.orion_feed", "sfx": { "on": "message_in" } },
+      { "from": "Mira", "textId": "ch5.mira_react", "sfx": { "on": "message_in" }, "anim": { "name": "fadeIn", "durationMs": 220 } },
+      { "from": "Alex", "choices": [ { "id": "dig", "labelId": "ui.next", "goto": "ch5.reaction", "sfx": { "on": "choice_show" } } ] }
+    ]
+  },
+  {
+    "id": "ch5.reaction",
+    "participants": ["Alex", "Mira"],
+    "messages": [
+      { "sys": "typing", "who": "Mira", "ms": 1100, "sfx": { "on": "typing_start" } },
+      { "from": "Mira", "textId": "ch5.mira_pressure", "effects": { "trust.Mira": 1 }, "sfx": { "on": "message_in" } },
+      { "from": "Alex", "choices": [ { "id": "loop", "labelId": "ui.next", "goto": "ch5.strategy", "sfx": { "on": "choice_show" } } ] }
+    ]
+  },
+  {
+    "id": "ch5.strategy",
+    "participants": ["Alex", "Orion"],
+    "messages": [
+      { "sys": "typing", "who": "Orion", "ms": 900, "sfx": { "on": "typing_start", "vol": 0.7 } },
+      { "from": "Orion", "textId": "ch5.orion_strategy", "effects": { "trust.Orion": 1 }, "sfx": { "on": "message_in" } },
+      {
+        "from": "Alex",
+        "choices": [
+          { "id": "considerPress", "labelId": "ch5.choice.press", "goto": "ch5.pressDebate", "sfx": { "on": "choice_show" } },
+          { "id": "considerSilence", "labelId": "ch5.choice.silence", "goto": "ch5.reflection", "sfx": { "on": "choice_show" } }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "ch5.pressDebate",
+    "participants": ["Alex", "Mira", "Orion"],
+    "messages": [
+      { "from": "Mira", "textId": "ch5.mira_press_case", "effects": { "trust.Mira": -1 }, "sfx": { "on": "message_in" }, "anim": { "name": "shake", "durationMs": 200 } },
+      { "from": "Orion", "textId": "ch5.orion_press_case", "effects": { "trust.Orion": 2 }, "sfx": { "on": "message_in" } },
+      { "from": "Alex", "choices": [ { "id": "weigh", "labelId": "ui.next", "goto": "ch5.reflection", "sfx": { "on": "choice_show" } } ] }
+    ]
+  },
+  {
+    "id": "ch5.reflection",
+    "participants": ["Alex", "System"],
+    "messages": [
+      { "sys": "typing", "who": "System", "ms": 600, "sfx": { "on": "typing_start" } },
+      { "from": "System", "textId": "ch5.system_summary", "sfx": { "on": "message_in" } },
+      { "from": "Alex", "choices": [ { "id": "decide", "labelId": "ch5.choice.decide", "goto": "ch5.branch", "sfx": { "on": "choice_show" }, "haptics": "medium" } ] }
+    ]
+  },
+  {
+    "id": "ch5.branch",
+    "participants": ["Alex", "Mira", "Orion"],
+    "messages": [
+      { "from": "Mira", "textId": "ch5.mira_final", "sfx": { "on": "message_in" } },
+      {
+        "from": "Alex",
+        "choices": [
+          { "id": "press", "labelId": "ch5.choice.press", "goto": "ch6.splitA", "effects": { "flags.pressRelease": true }, "sfx": { "on": "choice_confirm" }, "haptics": "firm" },
+          { "id": "silence", "labelId": "ch5.choice.silence", "goto": "ch6.splitB", "effects": { "flags.pressRelease": false }, "sfx": { "on": "choice_confirm" }, "haptics": "soft" }
+        ]
+      }
+    ]
+  }
+]

--- a/data/scenes/ch6_shadow.json
+++ b/data/scenes/ch6_shadow.json
@@ -1,0 +1,58 @@
+[
+  {
+    "id": "ch6.splitA",
+    "participants": ["Alex", "Orion"],
+    "messages": [
+      { "sys": "status", "textId": "ch6.splitA_status", "sfx": { "on": "checkpoint", "vol": 0.9 }, "anim": { "name": "fadeIn", "durationMs": 300 } },
+      { "from": "Orion", "textId": "ch6.orion_press_channel", "effects": { "trust.Orion": 1 }, "sfx": { "on": "message_in" } },
+      { "from": "Alex", "choices": [ { "id": "follow", "labelId": "ui.next", "goto": "ch6.pressThread", "sfx": { "on": "choice_show" } } ] }
+    ]
+  },
+  {
+    "id": "ch6.pressThread",
+    "participants": ["Alex", "Orion", "Mira"],
+    "messages": [
+      { "sys": "typing", "who": "Mira", "ms": 1000, "sfx": { "on": "typing_start" } },
+      { "from": "Mira", "textId": "ch6.mira_press_nerves", "effects": { "trust.Mira": -1 }, "sfx": { "on": "message_in" }, "anim": { "name": "shake", "durationMs": 200 } },
+      { "from": "Orion", "textId": "ch6.orion_press_updates", "sfx": { "on": "message_in" } },
+      { "from": "Alex", "choices": [ { "id": "merge", "labelId": "ui.next", "goto": "ch6.merge", "sfx": { "on": "choice_show" } } ] }
+    ]
+  },
+  {
+    "id": "ch6.splitB",
+    "participants": ["Alex", "Mira"],
+    "messages": [
+      { "sys": "status", "textId": "ch6.splitB_status", "sfx": { "on": "checkpoint" }, "anim": { "name": "fadeIn", "durationMs": 300 } },
+      { "from": "Mira", "textId": "ch6.mira_silence_channel", "effects": { "trust.Mira": 2 }, "sfx": { "on": "message_in" } },
+      { "from": "Alex", "choices": [ { "id": "follow", "labelId": "ui.next", "goto": "ch6.silenceThread", "sfx": { "on": "choice_show" } } ] }
+    ]
+  },
+  {
+    "id": "ch6.silenceThread",
+    "participants": ["Alex", "Mira", "Orion"],
+    "messages": [
+      { "sys": "typing", "who": "Orion", "ms": 900, "sfx": { "on": "typing_start", "vol": 0.6 } },
+      { "from": "Orion", "textId": "ch6.orion_silence_concern", "effects": { "trust.Orion": -1 }, "sfx": { "on": "message_in" } },
+      { "from": "Mira", "textId": "ch6.mira_silence_resolve", "sfx": { "on": "message_in" } },
+      { "from": "Alex", "choices": [ { "id": "merge", "labelId": "ui.next", "goto": "ch6.merge", "sfx": { "on": "choice_show" } } ] }
+    ]
+  },
+  {
+    "id": "ch6.merge",
+    "participants": ["Alex", "Mira", "Orion"],
+    "messages": [
+      { "sys": "typing", "who": "System", "ms": 700, "sfx": { "on": "typing_start" } },
+      { "from": "System", "textId": "ch6.system_merge", "sfx": { "on": "message_in" } },
+      { "from": "Alex", "choices": [ { "id": "wrap", "labelId": "ui.next", "goto": "ch6.out", "sfx": { "on": "choice_show" }, "haptics": "medium" } ] }
+    ]
+  },
+  {
+    "id": "ch6.out",
+    "participants": ["Alex", "Mira", "Orion"],
+    "messages": [
+      { "from": "Mira", "textId": "ch6.mira_outro", "sfx": { "on": "message_in" }, "anim": { "name": "fadeIn", "durationMs": 240 } },
+      { "from": "Orion", "textId": "ch6.orion_outro", "sfx": { "on": "message_in" } },
+      { "from": "Alex", "choices": [ { "id": "forward", "labelId": "ui.next", "goto": "ch7.entry", "sfx": { "on": "choice_show" } } ] }
+    ]
+  }
+]

--- a/data/scenes/ch7_climax.json
+++ b/data/scenes/ch7_climax.json
@@ -1,0 +1,67 @@
+[
+  {
+    "id": "ch7.entry",
+    "participants": ["Alex", "Mira", "Orion"],
+    "messages": [
+      { "sys": "status", "textId": "ch7.entry_status", "sfx": { "on": "checkpoint", "vol": 0.9 }, "anim": { "name": "fadeIn", "durationMs": 320 } },
+      { "from": "Mira", "textId": "ch7.mira_check", "sfx": { "on": "message_in" } },
+      { "from": "Orion", "textId": "ch7.orion_check", "sfx": { "on": "message_in" } },
+      { "from": "Alex", "choices": [ { "id": "assess", "labelId": "ui.next", "goto": "ch7.crossroads", "sfx": { "on": "choice_show" } } ] }
+    ]
+  },
+  {
+    "id": "ch7.crossroads",
+    "participants": ["Alex", "System"],
+    "messages": [
+      { "sys": "typing", "who": "System", "ms": 700, "sfx": { "on": "typing_start" } },
+      { "from": "System", "textId": "ch7.system_trust", "sfx": { "on": "message_in" } },
+      {
+        "from": "Alex",
+        "choices": [
+          { "id": "highTrust", "labelId": "ch7.choice.rely", "goto": "ch7.trustHigh", "requires": { "trust.Mira": { ">=": 4 } }, "sfx": { "on": "choice_confirm" } },
+          { "id": "lowTrust", "labelId": "ch7.choice.control", "goto": "ch7.trustLow", "requires": { "trust.Mira": { "<": 4 } }, "sfx": { "on": "choice_confirm" } }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "ch7.trustHigh",
+    "participants": ["Alex", "Mira"],
+    "messages": [
+      { "from": "Mira", "textId": "ch7.mira_trust_high", "effects": { "trust.Mira": 1 }, "sfx": { "on": "message_in", "vol": 0.85 }, "anim": { "name": "fadeIn", "durationMs": 220 } },
+      { "from": "Alex", "choices": [ { "id": "advance", "labelId": "ui.next", "goto": "ch7.confront", "sfx": { "on": "choice_show" } } ] }
+    ]
+  },
+  {
+    "id": "ch7.trustLow",
+    "participants": ["Alex", "Mira"],
+    "messages": [
+      { "from": "Mira", "textId": "ch7.mira_trust_low", "effects": { "trust.Mira": -1 }, "sfx": { "on": "message_in", "vol": 0.7 }, "anim": { "name": "shake", "durationMs": 220 } },
+      { "from": "Alex", "choices": [ { "id": "advance", "labelId": "ui.next", "goto": "ch7.confront", "sfx": { "on": "choice_show" } } ] }
+    ]
+  },
+  {
+    "id": "ch7.confront",
+    "participants": ["Alex", "Mira", "Orion"],
+    "messages": [
+      { "from": "Orion", "textId": "ch7.orion_pressure", "sfx": { "on": "message_in" } },
+      {
+        "from": "Alex",
+        "choices": [
+          { "id": "escalate", "labelId": "ch7.choice.escalate", "goto": "ch7.peak", "effects": { "trust.Orion": 1 }, "sfx": { "on": "choice_show" } },
+          { "id": "steady", "labelId": "ch7.choice.steady", "goto": "ch7.peak", "effects": { "trust.Mira": 1 }, "sfx": { "on": "choice_show" }, "haptics": "soft" }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "ch7.peak",
+    "participants": ["Alex", "Mira", "Orion"],
+    "messages": [
+      { "sys": "typing", "who": "Mira", "ms": 1500, "sfx": { "on": "typing_start", "vol": 0.8 } },
+      { "from": "Mira", "textId": "ch7.mira_peak", "sfx": { "on": "message_in" }, "anim": { "name": "fadeIn", "durationMs": 260 } },
+      { "from": "Orion", "textId": "ch7.orion_peak", "sfx": { "on": "message_in" } },
+      { "from": "Alex", "choices": [ { "id": "toNext", "labelId": "ui.next", "goto": "ch8.entry", "sfx": { "on": "choice_show" } } ] }
+    ]
+  }
+]

--- a/data/scenes/ch8_trust.json
+++ b/data/scenes/ch8_trust.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ch8.entry",
+    "participants": ["Alex", "Mira", "Orion"],
+    "messages": [
+      { "sys": "status", "textId": "ch8.entry_status", "sfx": { "on": "checkpoint" }, "anim": { "name": "fadeIn", "durationMs": 320 } },
+      { "from": "Mira", "textId": "ch8.mira_ready", "sfx": { "on": "message_in" } },
+      { "from": "Alex", "choices": [ { "id": "focus", "labelId": "ui.next", "goto": "ch8.focus", "sfx": { "on": "choice_show" } } ] }
+    ]
+  },
+  {
+    "id": "ch8.focus",
+    "participants": ["Alex", "Orion"],
+    "messages": [
+      { "sys": "typing", "who": "Orion", "ms": 900, "sfx": { "on": "typing_start" } },
+      { "from": "Orion", "textId": "ch8.orion_focus", "effects": { "trust.Orion": 1 }, "sfx": { "on": "message_in" } },
+      { "from": "Alex", "choices": [ { "id": "build", "labelId": "ui.next", "goto": "ch8.build", "sfx": { "on": "choice_show" } } ] }
+    ]
+  },
+  {
+    "id": "ch8.build",
+    "participants": ["Alex", "Mira"],
+    "messages": [
+      { "sys": "typing", "who": "Mira", "ms": 1200, "sfx": { "on": "typing_start", "vol": 0.7 } },
+      { "from": "Mira", "textId": "ch8.mira_share", "effects": { "trust.Mira": 1 }, "sfx": { "on": "message_in" } },
+      { "from": "Alex", "choices": [ { "id": "start", "labelId": "ui.start", "goto": "ch8.challenge", "sfx": { "on": "choice_show" }, "haptics": "medium" } ] }
+    ]
+  },
+  {
+    "id": "ch8.challenge",
+    "participants": ["Alex", "System"],
+    "messages": [
+      {
+        "miniGame": {
+          "kind": "trust",
+          "id": "mg8.trust",
+          "params": { "stages": 3, "target": "Mira", "timeLimitMs": 60000 },
+          "onSuccess": { "goto": "ch8.success", "effects": { "trust.Mira": 3 }, "sfx": { "on": "checkpoint" }, "haptics": "medium" },
+          "onFail": { "goto": "ch8.fail", "effects": { "trust.Mira": -3 }, "sfx": { "on": "error" }, "haptics": "heavy" }
+        }
+      }
+    ]
+  },
+  {
+    "id": "ch8.success",
+    "participants": ["Alex", "Mira", "Orion"],
+    "messages": [
+      { "from": "Mira", "textId": "ch8.mira_success", "sfx": { "on": "message_in", "vol": 0.9 }, "anim": { "name": "fadeIn", "durationMs": 240 } },
+      { "from": "Orion", "textId": "ch8.orion_success", "sfx": { "on": "message_in" } },
+      { "from": "Alex", "choices": [ { "id": "forward", "labelId": "ui.next", "goto": "ch9.entry", "sfx": { "on": "choice_show" } } ] }
+    ]
+  },
+  {
+    "id": "ch8.fail",
+    "participants": ["Alex", "Mira", "Orion"],
+    "messages": [
+      { "from": "Mira", "textId": "ch8.mira_fail", "effects": { "trust.Mira": -1 }, "sfx": { "on": "message_in", "vol": 0.7 } },
+      { "from": "Orion", "textId": "ch8.orion_fail", "effects": { "trust.Orion": -1 }, "sfx": { "on": "message_in" } },
+      { "from": "Alex", "choices": [ { "id": "forward", "labelId": "ui.next", "goto": "ch9.entry", "sfx": { "on": "choice_show" } } ] }
+    ]
+  }
+]

--- a/data/scenes/ch9_breakin.json
+++ b/data/scenes/ch9_breakin.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ch9.entry",
+    "participants": ["Alex", "Mira", "Orion"],
+    "messages": [
+      { "sys": "status", "textId": "ch9.entry_status", "sfx": { "on": "checkpoint", "vol": 0.9 }, "anim": { "name": "fadeIn", "durationMs": 320 } },
+      { "from": "Orion", "textId": "ch9.orion_lock_brief", "sfx": { "on": "message_in" } },
+      { "from": "Alex", "choices": [ { "id": "prep", "labelId": "ui.next", "goto": "ch9.brief", "sfx": { "on": "choice_show" } } ] }
+    ]
+  },
+  {
+    "id": "ch9.brief",
+    "participants": ["Alex", "Mira"],
+    "messages": [
+      { "sys": "typing", "who": "Mira", "ms": 1000, "sfx": { "on": "typing_start" } },
+      { "from": "Mira", "textId": "ch9.mira_lock_story", "sfx": { "on": "message_in" } },
+      { "from": "Alex", "choices": [ { "id": "scan", "labelId": "ui.next", "goto": "ch9.scan", "sfx": { "on": "choice_show" } } ] }
+    ]
+  },
+  {
+    "id": "ch9.scan",
+    "participants": ["Alex", "System"],
+    "messages": [
+      { "sys": "typing", "who": "System", "ms": 800, "sfx": { "on": "typing_start" } },
+      { "from": "System", "textId": "ch9.system_scan", "sfx": { "on": "message_in" } },
+      { "from": "Alex", "choices": [ { "id": "start", "labelId": "ui.start", "goto": "ch9.challenge", "sfx": { "on": "choice_show" }, "haptics": "medium" } ] }
+    ]
+  },
+  {
+    "id": "ch9.challenge",
+    "participants": ["Alex", "System"],
+    "messages": [
+      {
+        "miniGame": {
+          "kind": "locker",
+          "id": "mg9.locker",
+          "params": { "maxTries": 4, "timeLimitMs": 75000 },
+          "onSuccess": { "goto": "ch9.success", "effects": { "flags.lockerOpened": true, "trust.Orion": 2 }, "sfx": { "on": "checkpoint" }, "haptics": "medium" },
+          "onFail": { "goto": "ch9.fail", "effects": { "trust.Mira": -2 }, "sfx": { "on": "error" }, "haptics": "heavy" }
+        }
+      }
+    ]
+  },
+  {
+    "id": "ch9.success",
+    "participants": ["Alex", "Mira", "Orion"],
+    "messages": [
+      { "from": "Orion", "textId": "ch9.orion_success", "sfx": { "on": "message_in", "vol": 0.9 }, "anim": { "name": "fadeIn", "durationMs": 240 } },
+      { "from": "Mira", "textId": "ch9.mira_success", "effects": { "trust.Mira": 2 }, "sfx": { "on": "message_in" } },
+      { "from": "Alex", "choices": [ { "id": "advance", "labelId": "ui.next", "goto": "ch10.setup", "sfx": { "on": "choice_show" } } ] }
+    ]
+  },
+  {
+    "id": "ch9.fail",
+    "participants": ["Alex", "Mira", "Orion"],
+    "messages": [
+      { "from": "Mira", "textId": "ch9.mira_fail", "sfx": { "on": "message_in", "vol": 0.7 } },
+      { "from": "Orion", "textId": "ch9.orion_fail", "effects": { "trust.Orion": -2 }, "sfx": { "on": "message_in" }, "anim": { "name": "shake", "durationMs": 220 } },
+      { "from": "Alex", "choices": [ { "id": "advance", "labelId": "ui.next", "goto": "ch10.setup", "sfx": { "on": "choice_show" } } ] }
+    ]
+  }
+]


### PR DESCRIPTION
## Summary
- rebuild chapter 1 and 2 scene chains to follow 6–8 scene requirement and proper trust routing
- add new scene JSON files for chapters 3 through 10, including mini-game hooks and trust/flag logic
- wire transitions through later chapters with branching endings based on trust thresholds and global flags

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e3d3806a148325934aae3681f28b9f